### PR TITLE
delete DeleteVersionUsingInvalidCharacters returns 0x80131600 error code for invalid characters. 

### DIFF
--- a/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServerSubscriptionEditionPreview_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServerSubscriptionEditionPreview_SHOULDMAY.deployment.ptfconfig
@@ -7,7 +7,7 @@
     <!-- Set R5Enabled to true to verify that server supports SOAP over HTTPS for enhancing the security of communication with protocol clients. Set R5Enabled to false to disable this requirement. -->
     <Property name="R5Enabled" value="true"/>
     <!-- Set R17600Enabled to true to verify that the server returns error code 0x81020073 to indicate that the fileName element of the DeleteVersion element contains (\t) not at the end. Set R17600Enabled to false to disable this requirement. -->
-    <Property name="R17600Enabled" value="true"/>
+    <Property name="R17600Enabled" value="false"/>
     <!-- Set R1780200Enabled to true to verify that the server returns error code 0x80131600, when the file does not exist. Set R1780200Enabled to false to disable this requirement. -->
     <Property name="R1780200Enabled" value="true"/>
     <!-- Set R17201Enabled to true to verify that the server returns error code 0x81020030 to indicate that the fileName element of the DeleteAllVersions element contains invalid characters except contains pound sign (#), question marks (?) and tab (\t) or backward slash (\) is at the end of fileName. Set R17201Enabled to false to disable this requirement. -->

--- a/SharePoint/Source/MS-VERSS/TestSuite/S03_ErrorConditions.cs
+++ b/SharePoint/Source/MS-VERSS/TestSuite/S03_ErrorConditions.cs
@@ -1878,9 +1878,8 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
 
             bool isR17601Enabled = Common.IsRequirementEnabled(17601, this.Site);
             bool isR19602Enabled = Common.IsRequirementEnabled(19602, this.Site);
-            bool isR1960102Enabled = Common.IsRequirementEnabled(1960102, this.Site);
 
-            if (isR17601Enabled || isR19602Enabled || isR1960102Enabled || Common.IsRequirementEnabled(17602, this.Site) || Common.IsRequirementEnabled(19701, this.Site) || Common.IsRequirementEnabled(17621, this.Site)
+            if (isR17601Enabled || isR19602Enabled || Common.IsRequirementEnabled(17602, this.Site) || Common.IsRequirementEnabled(19701, this.Site) || Common.IsRequirementEnabled(17621, this.Site)
                 || Common.IsRequirementEnabled(19703, this.Site) || Common.IsRequirementEnabled(17600, this.Site) || Common.IsRequirementEnabled(19620, this.Site)|| Common.IsRequirementEnabled(19707, this.Site))
             {
                 foreach (string invalidCharacter in invalidCharacters)
@@ -1926,16 +1925,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                    errorCode,
                                    19603,
                                    @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Double quotation mark (""). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
-                            }
-
-                            if (isR1960102Enabled)
-                            {
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960103
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960103,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Double quotation mark (""). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
                             }
                         }
                         else if (invalidCharacter == "#")
@@ -1992,19 +1981,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     19605,
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Percent sign (%). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
-
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960105");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960105
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960105,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Percent sign (%). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                         else if (invalidCharacter == "&")
                         {
@@ -2032,19 +2008,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     errorCode,
                                     19606,
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Ampersand (&). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
-                            }
-
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960106");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960106
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960106,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Ampersand (&). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
                             }
                         }
                         else if (invalidCharacter == "*")
@@ -2075,18 +2038,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Asterisk (*). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
 
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960107");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960107
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960107,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Asterisk (*). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                         else if (invalidCharacter == ":")
                         {
@@ -2116,18 +2067,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Colon (:). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
 
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960108");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960108
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960108,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Colon (:). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                         else if (invalidCharacter == "<")
                         {
@@ -2157,18 +2096,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Left angle bracket (<). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
 
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960109");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960109
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960109,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Left angle bracket (<). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                          else if (invalidCharacter == "=")
                         {
@@ -2219,18 +2146,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Right angle bracket (>). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
 
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960111");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960111
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960111,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Right angle bracket (>). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                         else if (invalidCharacter == "=")
                         {
@@ -2303,19 +2218,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     19614,
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Left curly bracket ({). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
-
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960114");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960114
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960114,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Left curly bracket ({). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                         else if (invalidCharacter == "|")
                         {
@@ -2345,18 +2247,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Vertical bar (|). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
 
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960115");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960115
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960115,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Vertical bar (|). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                         else if (invalidCharacter == "}")
                         {
@@ -2386,18 +2276,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Right curly bracket (}). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
 
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960116");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960116
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960116,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Right curly bracket (}). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                         else if (invalidCharacter == "~")
                         {
@@ -2427,18 +2305,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Tilde (~). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
 
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960117");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960117
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960117,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Tilde (~). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                         else if (invalidCharacter == "/")
                         {
@@ -2467,19 +2333,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     19604,
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Forward slash (/). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
                             }
-
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960104");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960104
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960104,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Forward slash (/). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
-                            }
                         }
                         else if (invalidCharacter == "..")
                         {
@@ -2507,19 +2360,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     errorCode,
                                     19618,
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Two consecutive dots (..). (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
-                            }
-
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960118");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960118
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960118,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character Two consecutive dots (..). (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
                             }
                         }
                         else if (invalidCharacter == "\t")
@@ -2570,19 +2410,6 @@ namespace Microsoft.Protocols.TestSuites.MS_VERSS
                                     errorCode,
                                     19619,
                                     @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character that has a value less than 32 or greater than 126. (<5> Section 3.1.4.2.2.2:  Windows SharePoint Services 3.0 returns the 0x81070970 error code for invalid characters.)");
-                            }
-
-                            if (isR1960102Enabled)
-                            {
-                                // Add the debug information
-                                Site.Log.Add(LogEntryKind.Debug, "Verify MS-VERSS_R1960119");
-
-                                // Verify MS-VERSS requirement: MS-VERSS_R1960119
-                                Site.CaptureRequirementIfAreEqual<string>(
-                                   "0x80131600",
-                                   errorCode,
-                                   1960119,
-                                   @"[In Appendix B: Product Behavior] Implementation does return error code 0x81070970 to indicate that the fileName element of the DeleteVersion element contains invalid character that has a value less than 32 or greater than 126. (<5> Section 3.1.4.2.2.2: SharePoint Server 2019 returns 0x80131600 error code for invalid characters.)");
                             }
                         }
                     }


### PR DESCRIPTION
delete DeleteVersionUsingInvalidCharacters returns 0x80131600 error code for invalid characters. 

R17600Enabled in the configuration file to change the value of false in SharePointServerSubscriptionEditionPreview.