### PR TITLE
Disable to run GetActivatedFeatures to an invalid site on SharePoint 2013 due to a TDI.

### DIFF
--- a/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServer2010_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServer2010_SHOULDMAY.deployment.ptfconfig
@@ -84,6 +84,8 @@
     <Property name="R1039Enabled" value="true" />
     <!-- Set R691Enabled to true to verify that type of complex type WebDefinition. Set R691Enabled to false to disable this requirement. -->
     <Property name="R691Enabled" value="true" />
+	<!-- Set R1040Enabled to true to verify that if the protocol client sends the GetActivatedFeaturesSoapIn request message to a protocol server URL that does not correspond to a site, the protocol server MUST return a SOAP fault. -->
+	<Property name="R1040Enabled" value="true" />
   </Properties>
 
 </TestSite>

--- a/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServer2013_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServer2013_SHOULDMAY.deployment.ptfconfig
@@ -84,6 +84,8 @@
     <Property name="R1039Enabled" value="true" />
     <!-- Set R691Enabled to true to verify that type of complex type WebDefinition. Set R691Enabled to false to disable this requirement. -->
     <Property name="R691Enabled" value="false" />
+	<!-- Set R1040Enabled to true to verify that if the protocol client sends the GetActivatedFeaturesSoapIn request message to a protocol server URL that does not correspond to a site, the protocol server MUST return a SOAP fault. -->
+	<Property name="R1040Enabled" value="false" />
   </Properties>
 
 </TestSite>

--- a/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServer2016_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServer2016_SHOULDMAY.deployment.ptfconfig
@@ -84,6 +84,8 @@
     <Property name="R1039Enabled" value="true" />
     <!-- Set R691Enabled to true to verify that type of complex type WebDefinition. Set R691Enabled to false to disable this requirement. -->
     <Property name="R691Enabled" value="false" />
+	<!-- Set R1040Enabled to true to verify that if the protocol client sends the GetActivatedFeaturesSoapIn request message to a protocol server URL that does not correspond to a site, the protocol server MUST return a SOAP fault. -->
+	<Property name="R1040Enabled" value="true" />
   </Properties>
 
 </TestSite>

--- a/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServer2019_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServer2019_SHOULDMAY.deployment.ptfconfig
@@ -84,6 +84,8 @@
     <Property name="R1039Enabled" value="true" />
     <!-- Set R691Enabled to true to verify that type of complex type WebDefinition. Set R691Enabled to false to disable this requirement. -->
     <Property name="R691Enabled" value="true" />
+	<!-- Set R1040Enabled to true to verify that if the protocol client sends the GetActivatedFeaturesSoapIn request message to a protocol server URL that does not correspond to a site, the protocol server MUST return a SOAP fault. -->
+	<Property name="R1040Enabled" value="true" />
   </Properties>
 
 </TestSite>

--- a/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServerSubscriptionEditionPreview_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-WEBSS/TestSuite/MS-WEBSS_SharePointServerSubscriptionEditionPreview_SHOULDMAY.deployment.ptfconfig
@@ -84,6 +84,8 @@
     <Property name="R1039Enabled" value="true" />
     <!-- Set R691Enabled to true to verify that type of complex type WebDefinition. Set R691Enabled to false to disable this requirement. -->
     <Property name="R691Enabled" value="true" />
+	<!-- Set R1040Enabled to true to verify that if the protocol client sends the GetActivatedFeaturesSoapIn request message to a protocol server URL that does not correspond to a site, the protocol server MUST return a SOAP fault. -->
+	<Property name="R1040Enabled" value="true" />
   </Properties>
 
 </TestSite>

--- a/SharePoint/Source/MS-WEBSS/TestSuite/S10_OperationsOnActivatedFeatures.cs
+++ b/SharePoint/Source/MS-WEBSS/TestSuite/S10_OperationsOnActivatedFeatures.cs
@@ -260,7 +260,10 @@ namespace Microsoft.Protocols.TestSuites.MS_WEBSS
             }
             try
             {
-                Adapter.GetActivatedFeatures();
+                if (Common.IsRequirementEnabled(1040, this.Site))
+                {
+                    Adapter.GetActivatedFeatures();
+                }
             }
             catch(SoapException)
             {


### PR DESCRIPTION
Disable to run GetActivatedFeatures to an invalid site on SharePoint 2013 due to a TDI.